### PR TITLE
Default from API for ServiceAttachment.reconcileConnections

### DIFF
--- a/mmv1/products/cloudrun/DomainMapping.yaml
+++ b/mmv1/products/cloudrun/DomainMapping.yaml
@@ -158,7 +158,7 @@ properties:
     description: Metadata associated with this DomainMapping.
     properties:
       - !ruby/object:Api::Type::KeyValuePairs
-        name: labels
+        name: 'labels'
         description: |-
           Map of string keys and values that can be used to organize and categorize
           (scope and select) objects. May match selectors of replication controllers
@@ -204,7 +204,7 @@ properties:
           project ID or project number.
         custom_flatten: templates/terraform/custom_flatten/set_to_project.go.erb
       - !ruby/object:Api::Type::KeyValuePairs
-        name: annotations
+        name: 'annotations'
         description: |-
           Annotations is a key value map stored with a resource that
           may be set by external tools to store and retrieve arbitrary metadata. More

--- a/mmv1/products/cloudrun/Service.yaml
+++ b/mmv1/products/cloudrun/Service.yaml
@@ -240,7 +240,7 @@ properties:
             default_from_api: true
             properties:
               - !ruby/object:Api::Type::KeyValuePairs
-                name: labels
+                name: 'labels'
                 description: |-
                   Map of string keys and values that can be used to organize and categorize
                   (scope and select) objects.
@@ -279,7 +279,7 @@ properties:
                 default_from_api: true
                 custom_expand: 'templates/terraform/custom_expand/default_to_project.go.erb'
               - !ruby/object:Api::Type::KeyValuePairs
-                name: annotations
+                name: 'annotations'
                 description: |-
                   Annotations is a key value map stored with a resource that
                   may be set by external tools to store and retrieve arbitrary metadata. More
@@ -971,7 +971,7 @@ properties:
     default_from_api: true
     properties:
       - !ruby/object:Api::Type::KeyValuePairs
-        name: labels
+        name: 'labels'
         description: |-
           Map of string keys and values that can be used to organize and categorize
           (scope and select) objects. May match selectors of replication controllers
@@ -1013,7 +1013,7 @@ properties:
         custom_flatten: templates/terraform/custom_flatten/set_to_project.go.erb
         custom_expand: 'templates/terraform/custom_expand/default_to_project.go.erb'
       - !ruby/object:Api::Type::KeyValuePairs
-        name: annotations
+        name: 'annotations'
         description: |-
           Annotations is a key value map stored with a resource that
           may be set by external tools to store and retrieve arbitrary metadata. More

--- a/mmv1/products/cloudrunv2/Job.yaml
+++ b/mmv1/products/cloudrunv2/Job.yaml
@@ -138,7 +138,7 @@ properties:
       Cloud Run API v2 does not support labels with `run.googleapis.com`, `cloud.googleapis.com`, `serving.knative.dev`, or `autoscaling.knative.dev` namespaces, and they will be rejected.
       All system labels in v1 now have a corresponding field in v2 Job.
   - !ruby/object:Api::Type::KeyValueAnnotations
-    name: "annotations"
+    name: 'annotations'
     description: |-
       Unstructured key value map that may be set by external tools to store and arbitrary metadata. They are not queryable and should be preserved when modifying objects.
 
@@ -229,7 +229,7 @@ properties:
           Cloud Run API v2 does not support labels with `run.googleapis.com`, `cloud.googleapis.com`, `serving.knative.dev`, or `autoscaling.knative.dev` namespaces, and they will be rejected.
           All system labels in v1 now have a corresponding field in v2 ExecutionTemplate.
       - !ruby/object:Api::Type::KeyValuePairs
-        name: "annotations"
+        name: 'annotations'
         description: |-
           Unstructured key value map that may be set by external tools to store and arbitrary metadata. They are not queryable and should be preserved when modifying objects.
 

--- a/mmv1/products/compute/ServiceAttachment.yaml
+++ b/mmv1/products/compute/ServiceAttachment.yaml
@@ -208,12 +208,10 @@ properties:
             create.
   - !ruby/object:Api::Type::Boolean
     name: reconcileConnections
-    default_value: true
+    default_from_api: true
     send_empty_value: true
     description: |
       This flag determines whether a consumer accept/reject list change can reconcile the statuses of existing ACCEPTED or REJECTED PSC endpoints.
 
       If false, connection policy update will only affect existing PENDING PSC endpoints. Existing ACCEPTED/REJECTED endpoints will remain untouched regardless how the connection policy is modified .
       If true, update will affect both PENDING and ACCEPTED/REJECTED PSC endpoints. For example, an ACCEPTED PSC endpoint will be moved to REJECTED if its project is added to the reject list.
-
-      For newly created service attachment, this boolean defaults to true.

--- a/mmv1/products/containerattached/Cluster.yaml
+++ b/mmv1/products/containerattached/Cluster.yaml
@@ -203,7 +203,7 @@ properties:
       The Kubernetes version of the cluster.
     output: true
   - !ruby/object:Api::Type::KeyValueAnnotations
-    name: annotations
+    name: 'annotations'
     description: |
       Optional. Annotations on the cluster. This field has the same
       restrictions as Kubernetes annotations. The total size of all keys and

--- a/mmv1/products/firebasehosting/Channel.yaml
+++ b/mmv1/products/firebasehosting/Channel.yaml
@@ -76,8 +76,8 @@ properties:
       The number of previous releases to retain on the channel for rollback or other
       purposes. Must be a number between 1-100. Defaults to 10 for new channels.
     default_from_api: true
-  - !ruby/object:Api::Type::KeyValuePairs
-    name: labels
+  - !ruby/object:Api::Type::KeyValueLabels
+    name: 'labels'
     description: Text labels used for extra metadata and/or filtering
   - !ruby/object:Api::Type::Time
     name: expireTime

--- a/mmv1/products/gkebackup/BackupPlan.yaml
+++ b/mmv1/products/gkebackup/BackupPlan.yaml
@@ -138,8 +138,8 @@ properties:
           If set to True, no further update is allowed on this policy, including
           the locked field itself.
         default_from_api: true
-  - !ruby/object:Api::Type::KeyValuePairs
-    name: labels
+  - !ruby/object:Api::Type::KeyValueLabels
+    name: 'labels'
     description: |
       Description: A set of custom labels supplied by the user.
       A list of key->value pairs.

--- a/mmv1/products/gkehub2/Feature.yaml
+++ b/mmv1/products/gkehub2/Feature.yaml
@@ -105,8 +105,8 @@ properties:
     diff_suppress_func: 'tpgresource.CompareSelfLinkOrResourceName'
     custom_expand: templates/terraform/custom_expand/resource_from_self_link.go.erb
     custom_flatten: templates/terraform/custom_flatten/name_from_self_link.erb
-  - !ruby/object:Api::Type::KeyValuePairs
-    name: labels
+  - !ruby/object:Api::Type::KeyValueLabels
+    name: 'labels'
     description: GCP labels for this Feature.
   - !ruby/object:Api::Type::NestedObject
     name: resourceState

--- a/mmv1/products/gkeonprem/BareMetalAdminCluster.yaml
+++ b/mmv1/products/gkeonprem/BareMetalAdminCluster.yaml
@@ -134,7 +134,7 @@ properties:
       through optimistic concurrency control.
     output: true
   - !ruby/object:Api::Type::KeyValueAnnotations
-    name: "annotations"
+    name: 'annotations'
     description: |
       Annotations on the Bare Metal Admin Cluster.
       This field has the same restrictions as Kubernetes annotations.
@@ -194,7 +194,7 @@ properties:
                         The default IPv4 address for SSH access and Kubernetes node.
                         Example: 192.168.0.1
                     - !ruby/object:Api::Type::KeyValuePairs
-                      name: "labels"
+                      name: 'labels'
                       description: |
                         The map of Kubernetes labels (key/value pairs) to be applied to
                         each node. These will added in addition to any default label(s)
@@ -233,7 +233,7 @@ properties:
                         - PREFER_NO_SCHEDULE
                         - NO_EXECUTE
               - !ruby/object:Api::Type::KeyValuePairs
-                name: "labels"
+                name: 'labels'
                 description: |
                   The map of Kubernetes labels (key/value pairs) to be applied to
                   each node. These will added in addition to any default label(s)

--- a/mmv1/products/gkeonprem/BareMetalCluster.yaml
+++ b/mmv1/products/gkeonprem/BareMetalCluster.yaml
@@ -86,7 +86,7 @@ properties:
     description: |
       A human readable description of this Bare Metal User Cluster.
   - !ruby/object:Api::Type::KeyValueAnnotations
-    name: "annotations"
+    name: 'annotations'
     description: |
       Annotations on the Bare Metal User Cluster.
       This field has the same restrictions as Kubernetes annotations.
@@ -176,7 +176,7 @@ properties:
                         The default IPv4 address for SSH access and Kubernetes node.
                         Example: 192.168.0.1
                     - !ruby/object:Api::Type::KeyValuePairs
-                      name: "labels"
+                      name: 'labels'
                       description: |
                         The map of Kubernetes labels (key/value pairs) to be applied to
                         each node. These will added in addition to any default label(s)
@@ -217,7 +217,7 @@ properties:
                         - PREFER_NO_SCHEDULE
                         - NO_EXECUTE
               - !ruby/object:Api::Type::KeyValuePairs
-                name: "labels"
+                name: 'labels'
                 description: |
                   The map of Kubernetes labels (key/value pairs) to be applied to
                   each node. These will added in addition to any default label(s)
@@ -340,7 +340,7 @@ properties:
                             The default IPv4 address for SSH access and Kubernetes node.
                             Example: 192.168.0.1
                         - !ruby/object:Api::Type::KeyValuePairs
-                          name: "labels"
+                          name: 'labels'
                           description: |
                             The map of Kubernetes labels (key/value pairs) to be applied to
                             each node. These will added in addition to any default label(s)
@@ -381,7 +381,7 @@ properties:
                             - PREFER_NO_SCHEDULE
                             - NO_EXECUTE
                   - !ruby/object:Api::Type::KeyValuePairs
-                    name: "labels"
+                    name: 'labels'
                     description: |
                       The map of Kubernetes labels (key/value pairs) to be applied to
                       each node. These will added in addition to any default label(s)
@@ -504,7 +504,7 @@ properties:
                             The default IPv4 address for SSH access and Kubernetes node.
                             Example: 192.168.0.1
                         - !ruby/object:Api::Type::KeyValuePairs
-                          name: "labels"
+                          name: 'labels'
                           description: |
                             The map of Kubernetes labels (key/value pairs) to be applied to
                             each node. These will added in addition to any default label(s)
@@ -543,7 +543,7 @@ properties:
                             - PREFER_NO_SCHEDULE
                             - NO_EXECUTE
                   - !ruby/object:Api::Type::KeyValuePairs
-                    name: "labels"
+                    name: 'labels'
                     description: |
                       The map of Kubernetes labels (key/value pairs) to be applied to
                       each node. These will added in addition to any default label(s)

--- a/mmv1/products/gkeonprem/VmwareNodePool.yaml
+++ b/mmv1/products/gkeonprem/VmwareNodePool.yaml
@@ -72,7 +72,7 @@ properties:
     name: "displayName"
     description: The display name for the node pool.
   - !ruby/object:Api::Type::KeyValueAnnotations
-    name: "annotations"
+    name: 'annotations'
     description: |
       Annotations on the node Pool.
       This field has the same restrictions as Kubernetes annotations.
@@ -148,7 +148,7 @@ properties:
                 - PREFER_NO_SCHEDULE
                 - NO_EXECUTE
       - !ruby/object:Api::Type::KeyValuePairs
-        name: "labels"
+        name: 'labels'
         description: |
           The map of Kubernetes labels (key/value pairs) to be applied to each node.
           These will added in addition to any default label(s) that

--- a/mmv1/products/healthcare/ConsentStore.yaml
+++ b/mmv1/products/healthcare/ConsentStore.yaml
@@ -93,8 +93,8 @@ properties:
     required: false
     description: |
       If true, [consents.patch] [google.cloud.healthcare.v1.consent.UpdateConsent] creates the consent if it does not already exist.
-  - !ruby/object:Api::Type::KeyValuePairs
-    name: labels
+  - !ruby/object:Api::Type::KeyValueLabels
+    name: 'labels'
     required: false
     description: |
       User-supplied key-value pairs used to organize Consent stores.

--- a/mmv1/products/healthcare/DicomStore.yaml
+++ b/mmv1/products/healthcare/DicomStore.yaml
@@ -73,8 +73,8 @@ properties:
       ** Changing this property may recreate the Dicom store (removing all data) **
     required: true
     immutable: true
-  - !ruby/object:Api::Type::KeyValuePairs
-    name: labels
+  - !ruby/object:Api::Type::KeyValueLabels
+    name: 'labels'
     required: false
     description: |
       User-supplied key-value pairs used to organize DICOM stores.

--- a/mmv1/products/healthcare/FhirStore.yaml
+++ b/mmv1/products/healthcare/FhirStore.yaml
@@ -166,8 +166,8 @@ properties:
       ** This property can be changed manually in the Google Cloud Healthcare admin console without recreating the FHIR store **
     required: false
     immutable: true
-  - !ruby/object:Api::Type::KeyValuePairs
-    name: labels
+  - !ruby/object:Api::Type::KeyValueLabels
+    name: 'labels'
     required: false
     description: |
       User-supplied key-value pairs used to organize FHIR stores.

--- a/mmv1/products/healthcare/Hl7V2Store.yaml
+++ b/mmv1/products/healthcare/Hl7V2Store.yaml
@@ -129,8 +129,8 @@ properties:
           - :V1
           - :V2
           - :V3
-  - !ruby/object:Api::Type::KeyValuePairs
-    name: labels
+  - !ruby/object:Api::Type::KeyValueLabels
+    name: 'labels'
     required: false
     description: |
       User-supplied key-value pairs used to organize HL7v2 stores.

--- a/mmv1/products/logging/Metric.yaml
+++ b/mmv1/products/logging/Metric.yaml
@@ -132,7 +132,7 @@ properties:
           - :CUMULATIVE
         required: true
       - !ruby/object:Api::Type::Array
-        name: labels
+        name: 'labels'
         description: |
           The set of labels that can be used to describe a specific instance of this metric type. For
           example, the appengine.googleapis.com/http/server/response_latencies metric type has a label

--- a/mmv1/products/monitoring/AlertPolicy.yaml
+++ b/mmv1/products/monitoring/AlertPolicy.yaml
@@ -859,7 +859,7 @@ properties:
                 alerting rule, then this value should be taken from the enclosing
                 rule group.
             - !ruby/object:Api::Type::KeyValuePairs
-              name: labels
+              name: 'labels'
               description: |
                 Labels to add to or overwrite in the PromQL query result. Label names
                 must be valid.

--- a/mmv1/products/monitoring/MetricDescriptor.yaml
+++ b/mmv1/products/monitoring/MetricDescriptor.yaml
@@ -69,7 +69,7 @@ properties:
       the DNS name custom.googleapis.com, external.googleapis.com, or
       logging.googleapis.com/user/.
   - !ruby/object:Api::Type::Array
-    name: labels
+    name: 'labels'
     description:
       The set of labels that can be used to describe a specific instance of this
       metric type. In order to delete a label, the entire resource must be

--- a/mmv1/products/monitoring/NotificationChannel.yaml
+++ b/mmv1/products/monitoring/NotificationChannel.yaml
@@ -79,7 +79,7 @@ custom_diff: [
 ]
 properties:
   - !ruby/object:Api::Type::KeyValuePairs
-    name: labels
+    name: 'labels'
     description: |
       Configuration fields that define the channel and its behavior. The
       permissible and required labels are specified in the

--- a/mmv1/products/monitoring/UptimeCheckConfig.yaml
+++ b/mmv1/products/monitoring/UptimeCheckConfig.yaml
@@ -402,7 +402,7 @@ properties:
           resource types
           (https://cloud.google.com/logging/docs/api/v2/resource-list).
       - !ruby/object:Api::Type::KeyValuePairs
-        name: labels
+        name: 'labels'
         immutable: true
         required: true
         description:

--- a/mmv1/products/networkconnectivity/ServiceConnectionPolicies.yaml
+++ b/mmv1/products/networkconnectivity/ServiceConnectionPolicies.yaml
@@ -205,7 +205,7 @@ properties:
     output: true
     description: |
       The type of underlying resources used to create the connection.
-  - !ruby/object:Api::Type::KeyValuePairs
-    name: "labels"
+  - !ruby/object:Api::Type::KeyValueLabels
+    name: 'labels'
     description: |
       User-defined labels.

--- a/mmv1/products/networksecurity/AddressGroup.yaml
+++ b/mmv1/products/networksecurity/AddressGroup.yaml
@@ -95,8 +95,8 @@ properties:
       A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine fractional digits.
       Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
     output: true
-  - !ruby/object:Api::Type::KeyValuePairs
-    name: "labels"
+  - !ruby/object:Api::Type::KeyValueLabels
+    name: 'labels'
     description: |
       Set of label tags associated with the AddressGroup resource.
       An object containing a list of "key": value pairs. Example: { "name": "wrench", "mass": "1.3kg", "count": "3" }.

--- a/mmv1/products/privateca/CaPool.yaml
+++ b/mmv1/products/privateca/CaPool.yaml
@@ -480,8 +480,8 @@ properties:
         values:
           - :PEM
           - :DER
-  - !ruby/object:Api::Type::KeyValuePairs
-    name: labels
+  - !ruby/object:Api::Type::KeyValueLabels
+    name: 'labels'
     description: |
       Labels with user-defined metadata.
 

--- a/mmv1/products/privateca/CertificateAuthority.yaml
+++ b/mmv1/products/privateca/CertificateAuthority.yaml
@@ -735,8 +735,8 @@ properties:
       A timestamp in RFC3339 UTC "Zulu" format, with nanosecond resolution and up to nine
       fractional digits. Examples: "2014-10-02T15:01:23Z" and "2014-10-02T15:01:23.045123456Z".
     output: true
-  - !ruby/object:Api::Type::KeyValuePairs
-    name: labels
+  - !ruby/object:Api::Type::KeyValueLabels
+    name: 'labels'
     description: |
       Labels with user-defined metadata.
 

--- a/mmv1/products/secretmanager/Secret.yaml
+++ b/mmv1/products/secretmanager/Secret.yaml
@@ -69,8 +69,8 @@ properties:
     output: true
     description: |
       The time at which the Secret was created.
-  - !ruby/object:Api::Type::KeyValuePairs
-    name: labels
+  - !ruby/object:Api::Type::KeyValueLabels
+    name: 'labels'
     description: |
       The labels assigned to this Secret.
 
@@ -85,7 +85,7 @@ properties:
       An object containing a list of "key": value pairs. Example:
       { "name": "wrench", "mass": "1.3kg", "count": "3" }.
   - !ruby/object:Api::Type::KeyValueAnnotations
-    name: annotations
+    name: 'annotations'
     description: |
       Custom metadata about the secret.
 

--- a/mmv1/products/vertexai/Endpoint.yaml
+++ b/mmv1/products/vertexai/Endpoint.yaml
@@ -359,8 +359,8 @@ properties:
       "overwrite" update happens.
     output: true
     ignore_read: true
-  - !ruby/object:Api::Type::KeyValuePairs
-    name: labels
+  - !ruby/object:Api::Type::KeyValueLabels
+    name: 'labels'
     description:
       The labels with user-defined metadata to organize your Endpoints. Label
       keys and values can be no longer than 64 characters (Unicode codepoints),

--- a/mmv1/products/workstations/WorkstationCluster.yaml
+++ b/mmv1/products/workstations/WorkstationCluster.yaml
@@ -89,8 +89,8 @@ properties:
     output: true
     description: |
       The system-generated UID of the resource.
-  - !ruby/object:Api::Type::KeyValuePairs
-    name: "labels"
+  - !ruby/object:Api::Type::KeyValueLabels
+    name: 'labels'
     description:
       "Client-specified labels that are applied to the resource and that are
       also propagated to the underlying Compute Engine resources."
@@ -119,7 +119,7 @@ properties:
       Details can be found in the conditions field.
     output: true
   - !ruby/object:Api::Type::KeyValueAnnotations
-    name: "annotations"
+    name: 'annotations'
     description: "Client-specified annotations. This is distinct from labels."
   - !ruby/object:Api::Type::Fingerprint
     name: "etag"

--- a/mmv1/third_party/terraform/services/firebasehosting/resource_firebase_hosting_channel_test.go.erb
+++ b/mmv1/third_party/terraform/services/firebasehosting/resource_firebase_hosting_channel_test.go.erb
@@ -75,7 +75,7 @@ func TestAccFirebaseHostingChannel_firebasehostingChannelUpdate(t *testing.T) {
 				ResourceName:            "google_firebase_hosting_channel.update",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ttl", "site_id", "channel_id"},
+				ImportStateVerifyIgnore: []string{"ttl", "site_id", "channel_id", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccFirebaseHostingChannel_firebasehostingChannelMultipleFields(context),
@@ -84,7 +84,7 @@ func TestAccFirebaseHostingChannel_firebasehostingChannelUpdate(t *testing.T) {
 				ResourceName:            "google_firebase_hosting_channel.update",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ttl", "site_id", "channel_id"},
+				ImportStateVerifyIgnore: []string{"ttl", "site_id", "channel_id", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccFirebaseHostingChannel_firebasehostingChannelBasic(context),

--- a/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_backup_plan_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkebackup/resource_gke_backup_backup_plan_test.go.erb
@@ -30,6 +30,7 @@ func TestAccGKEBackupBackupPlan_update(t *testing.T) {
 				ResourceName:      "google_gke_backup_backup_plan.backupplan",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
 				Config: testAccGKEBackupBackupPlan_full(context),
@@ -38,6 +39,7 @@ func TestAccGKEBackupBackupPlan_update(t *testing.T) {
 				ResourceName:      "google_gke_backup_backup_plan.backupplan",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 		},
 	})
@@ -67,6 +69,9 @@ resource "google_gke_backup_backup_plan" "backupplan" {
 	include_volume_data = false
 	include_secrets = false
 	all_namespaces = true
+  }
+  labels = {
+    "some-key-1": "some-value-1"
   }
 }
 `, context)
@@ -112,6 +117,9 @@ resource "google_gke_backup_backup_plan" "backupplan" {
 	    namespace = "ns2"
 	  }
     }
+  }
+  labels = {
+    "some-key-2": "some-value-2"
   }
 }
 `, context)

--- a/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.erb
+++ b/mmv1/third_party/terraform/services/gkehub2/resource_gke_hub_feature_test.go.erb
@@ -231,7 +231,7 @@ func TestAccGKEHubFeature_gkehubFeatureMciUpdate(t *testing.T) {
 				ResourceName:      "google_gke_hub_feature.feature",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"update_time"},
+				ImportStateVerifyIgnore: []string{"update_time", "labels", "terraform_labels"},
 			},
 		},
 	})
@@ -366,7 +366,7 @@ func TestAccGKEHubFeature_gkehubFeatureMcsd(t *testing.T) {
 				ResourceName:            "google_gke_hub_feature.feature",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"project"},
+				ImportStateVerifyIgnore: []string{"project", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccGKEHubFeature_gkehubFeatureMcsdUpdate(context),
@@ -375,6 +375,7 @@ func TestAccGKEHubFeature_gkehubFeatureMcsd(t *testing.T) {
 				ResourceName:      "google_gke_hub_feature.feature",
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/healthcare/resource_healthcare_dicom_store_test.go
+++ b/mmv1/third_party/terraform/services/healthcare/resource_healthcare_dicom_store_test.go
@@ -91,9 +91,10 @@ func TestAccHealthcareDicomStore_basic(t *testing.T) {
 				Config: testGoogleHealthcareDicomStore_basic(dicomStoreName, datasetName),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
 				Config: testGoogleHealthcareDicomStore_update(dicomStoreName, datasetName, pubsubTopic),
@@ -102,17 +103,19 @@ func TestAccHealthcareDicomStore_basic(t *testing.T) {
 				),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
 				Config: testGoogleHealthcareDicomStore_basic(dicomStoreName, datasetName),
 			},
 			{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/healthcare/resource_healthcare_fhir_store_test.go.erb
+++ b/mmv1/third_party/terraform/services/healthcare/resource_healthcare_fhir_store_test.go.erb
@@ -95,6 +95,7 @@ func TestAccHealthcareFhirStore_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
 				Config: testGoogleHealthcareFhirStore_update(fhirStoreName, datasetName, pubsubTopic),
@@ -106,6 +107,7 @@ func TestAccHealthcareFhirStore_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
 				Config: testGoogleHealthcareFhirStore_basic(fhirStoreName, datasetName),
@@ -114,6 +116,7 @@ func TestAccHealthcareFhirStore_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/healthcare/resource_healthcare_hl7_v2_store_test.go.erb
+++ b/mmv1/third_party/terraform/services/healthcare/resource_healthcare_hl7_v2_store_test.go.erb
@@ -95,6 +95,7 @@ func TestAccHealthcareHl7V2Store_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
 				Config: testGoogleHealthcareHl7V2Store_update(hl7_v2StoreName, datasetName, pubsubTopic),
@@ -106,6 +107,7 @@ func TestAccHealthcareHl7V2Store_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
 				Config: testGoogleHealthcareHl7V2Store_basic(hl7_v2StoreName, datasetName),
@@ -114,6 +116,7 @@ func TestAccHealthcareHl7V2Store_basic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_service_connection_policies_test.go
+++ b/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_service_connection_policies_test.go
@@ -27,25 +27,28 @@ func TestAccNetworkConnectivityServiceConnectionPolicy_update(t *testing.T) {
 				Config: testAccNetworkConnectivityServiceConnectionPolicy_basic(context),
 			},
 			{
-				ResourceName:      "google_network_connectivity_service_connection_policy.default",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_network_connectivity_service_connection_policy.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
 				Config: testAccNetworkConnectivityServiceConnectionPolicy_update(context),
 			},
 			{
-				ResourceName:      "google_network_connectivity_service_connection_policy.default",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_network_connectivity_service_connection_policy.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
 				Config: testAccNetworkConnectivityServiceConnectionPolicy_basic(context),
 			},
 			{
-				ResourceName:      "google_network_connectivity_service_connection_policy.default",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_network_connectivity_service_connection_policy.default",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/networksecurity/resource_network_security_address_group_test.go
+++ b/mmv1/third_party/terraform/services/networksecurity/resource_network_security_address_group_test.go
@@ -24,17 +24,19 @@ func TestAccNetworkSecurityAddressGroups_update(t *testing.T) {
 				Config: testAccNetworkSecurityAddressGroups_basic(addressGroupsName, projectName),
 			},
 			{
-				ResourceName:      "google_network_security_address_group.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_network_security_address_group.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 			{
 				Config: testAccNetworkSecurityAddressGroups_update(addressGroupsName, projectName),
 			},
 			{
-				ResourceName:      "google_network_security_address_group.foobar",
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            "google_network_security_address_group.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/privateca/resource_privateca_ca_pool_test.go
+++ b/mmv1/third_party/terraform/services/privateca/resource_privateca_ca_pool_test.go
@@ -26,7 +26,7 @@ func TestAccPrivatecaCaPool_privatecaCapoolUpdate(t *testing.T) {
 				ResourceName:            "google_privateca_ca_pool.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"name", "location"},
+				ImportStateVerifyIgnore: []string{"name", "location", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccPrivatecaCaPool_privatecaCapoolEnd(context),
@@ -35,7 +35,7 @@ func TestAccPrivatecaCaPool_privatecaCapoolUpdate(t *testing.T) {
 				ResourceName:            "google_privateca_ca_pool.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"name", "location"},
+				ImportStateVerifyIgnore: []string{"name", "location", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccPrivatecaCaPool_privatecaCapoolStart(context),
@@ -44,7 +44,7 @@ func TestAccPrivatecaCaPool_privatecaCapoolUpdate(t *testing.T) {
 				ResourceName:            "google_privateca_ca_pool.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"name", "location"},
+				ImportStateVerifyIgnore: []string{"name", "location", "labels", "terraform_labels"},
 			},
 		},
 	})
@@ -233,7 +233,7 @@ func TestAccPrivatecaCaPool_privatecaCapoolEmptyBaseline(t *testing.T) {
 				ResourceName:            "google_privateca_ca_pool.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"name", "location"},
+				ImportStateVerifyIgnore: []string{"name", "location", "labels", "terraform_labels"},
 			},
 		},
 	})
@@ -297,7 +297,7 @@ func TestAccPrivatecaCaPool_privatecaCapoolEmptyPublishingOptions(t *testing.T) 
 				ResourceName:            "google_privateca_ca_pool.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"name", "location"},
+				ImportStateVerifyIgnore: []string{"name", "location", "labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/privateca/resource_privateca_certificate_authority_test.go
+++ b/mmv1/third_party/terraform/services/privateca/resource_privateca_certificate_authority_test.go
@@ -34,7 +34,7 @@ func TestAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityUpdate(t 
 				ResourceName:            "google_privateca_certificate_authority.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ignore_active_certificates_on_deletion", "location", "certificate_authority_id", "pool", "deletion_protection", "skip_grace_period"},
+				ImportStateVerifyIgnore: []string{"ignore_active_certificates_on_deletion", "location", "certificate_authority_id", "pool", "deletion_protection", "skip_grace_period", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityEnd(context),
@@ -43,7 +43,7 @@ func TestAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityUpdate(t 
 				ResourceName:            "google_privateca_certificate_authority.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ignore_active_certificates_on_deletion", "location", "certificate_authority_id", "pool", "deletion_protection", "skip_grace_period"},
+				ImportStateVerifyIgnore: []string{"ignore_active_certificates_on_deletion", "location", "certificate_authority_id", "pool", "deletion_protection", "skip_grace_period", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityBasicRoot(context),
@@ -52,7 +52,7 @@ func TestAccPrivatecaCertificateAuthority_privatecaCertificateAuthorityUpdate(t 
 				ResourceName:            "google_privateca_certificate_authority.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ignore_active_certificates_on_deletion", "location", "certificate_authority_id", "pool", "deletion_protection", "skip_grace_period"},
+				ImportStateVerifyIgnore: []string{"ignore_active_certificates_on_deletion", "location", "certificate_authority_id", "pool", "deletion_protection", "skip_grace_period", "labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secret_test.go
+++ b/mmv1/third_party/terraform/services/secretmanager/data_source_secret_manager_secret_test.go
@@ -22,7 +22,11 @@ func TestAccDataSourceSecretManagerSecret_basic(t *testing.T) {
 			{
 				Config: testAccDataSourceSecretManagerSecret_basic(context),
 				Check: resource.ComposeTestCheckFunc(
-					acctest.CheckDataSourceStateMatchesResourceState("data.google_secret_manager_secret.foo", "google_secret_manager_secret.bar"),
+					acctest.CheckDataSourceStateMatchesResourceStateWithIgnores(
+						"data.google_secret_manager_secret.foo",
+						"google_secret_manager_secret.bar",
+						map[string]struct{}{"zone": {}, "labels.%": {}, "terraform_labels.%": {}},
+					),
 				),
 			},
 		},

--- a/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go.erb
+++ b/mmv1/third_party/terraform/services/secretmanager/resource_secret_manager_secret_test.go.erb
@@ -29,7 +29,7 @@ func TestAccSecretManagerSecret_import(t *testing.T) {
 				ResourceName:      "google_secret_manager_secret.secret-basic",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"ttl"},
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
 			},
 		},
 	})
@@ -58,7 +58,7 @@ func TestAccSecretManagerSecret_cmek(t *testing.T) {
 				ResourceName:      "google_secret_manager_secret.secret-basic",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"ttl"},
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
 			},
 		},
 	})
@@ -126,7 +126,7 @@ func TestAccSecretManagerSecret_versionAliasesUpdate(t *testing.T) {
 				ResourceName:      "google_secret_manager_secret.secret-basic",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"ttl"},
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccSecretManagerSecret_versionAliasesBasic(context),
@@ -135,7 +135,7 @@ func TestAccSecretManagerSecret_versionAliasesUpdate(t *testing.T) {
 				ResourceName:      "google_secret_manager_secret.secret-basic",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"ttl"},
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccSecretManagerSecret_versionAliasesUpdate(context),
@@ -144,7 +144,7 @@ func TestAccSecretManagerSecret_versionAliasesUpdate(t *testing.T) {
 				ResourceName:      "google_secret_manager_secret.secret-basic",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"ttl"},
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccSecretManagerSecret_basicWithSecretVersions(context),
@@ -153,7 +153,7 @@ func TestAccSecretManagerSecret_versionAliasesUpdate(t *testing.T) {
 				ResourceName:      "google_secret_manager_secret.secret-basic",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{"ttl"},
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
 			},
 		},
 	})
@@ -184,7 +184,7 @@ func TestAccSecretManagerSecret_userManagedCmekUpdate(t *testing.T) {
 				ResourceName:            "google_secret_manager_secret.secret-basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ttl"},
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccSecretMangerSecret_userManagedCmekUpdate(context),
@@ -193,7 +193,7 @@ func TestAccSecretManagerSecret_userManagedCmekUpdate(t *testing.T) {
 				ResourceName:            "google_secret_manager_secret.secret-basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ttl"},
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccSecretMangerSecret_userManagedCmekUpdate2(context),
@@ -202,7 +202,7 @@ func TestAccSecretManagerSecret_userManagedCmekUpdate(t *testing.T) {
 				ResourceName:            "google_secret_manager_secret.secret-basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ttl"},
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccSecretMangerSecret_userManagedCmekBasic(context),
@@ -211,7 +211,7 @@ func TestAccSecretManagerSecret_userManagedCmekUpdate(t *testing.T) {
 				ResourceName:            "google_secret_manager_secret.secret-basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ttl"},
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
 			},
 		},
 	})
@@ -241,7 +241,7 @@ func TestAccSecretManagerSecret_automaticCmekUpdate(t *testing.T) {
 				ResourceName:            "google_secret_manager_secret.secret-basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ttl"},
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccSecretMangerSecret_automaticCmekUpdate(context),
@@ -250,7 +250,7 @@ func TestAccSecretManagerSecret_automaticCmekUpdate(t *testing.T) {
 				ResourceName:            "google_secret_manager_secret.secret-basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ttl"},
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccSecretMangerSecret_automaticCmekUpdate2(context),
@@ -259,7 +259,7 @@ func TestAccSecretManagerSecret_automaticCmekUpdate(t *testing.T) {
 				ResourceName:            "google_secret_manager_secret.secret-basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ttl"},
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccSecretMangerSecret_automaticCmekBasic(context),
@@ -268,7 +268,7 @@ func TestAccSecretManagerSecret_automaticCmekUpdate(t *testing.T) {
 				ResourceName:            "google_secret_manager_secret.secret-basic",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"ttl"},
+				ImportStateVerifyIgnore: []string{"ttl", "labels", "terraform_labels"},
 			},
 		},
 	})

--- a/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_cluster_test.go.erb
+++ b/mmv1/third_party/terraform/services/workstations/resource_workstations_workstation_cluster_test.go.erb
@@ -28,7 +28,7 @@ func TestAccWorkstationsWorkstationCluster_update(t *testing.T) {
 				ResourceName:            "google_workstations_workstation_cluster.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "annotations"},
+				ImportStateVerifyIgnore: []string{"etag", "annotations", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccWorkstationsWorkstationCluster_update(context),
@@ -37,7 +37,7 @@ func TestAccWorkstationsWorkstationCluster_update(t *testing.T) {
 				ResourceName:            "google_workstations_workstation_cluster.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "annotations"},
+				ImportStateVerifyIgnore: []string{"etag", "annotations", "labels", "terraform_labels"},
 			},
 		},
 	})
@@ -62,7 +62,7 @@ func TestAccWorkstationsWorkstationCluster_Private_update(t *testing.T) {
 				ResourceName:            "google_workstations_workstation_cluster.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "annotations"},
+				ImportStateVerifyIgnore: []string{"etag", "annotations", "labels", "terraform_labels"},
 			},
 			{
 				Config: testAccWorkstationsWorkstationCluster_private_update(context),
@@ -71,7 +71,7 @@ func TestAccWorkstationsWorkstationCluster_Private_update(t *testing.T) {
 				ResourceName:            "google_workstations_workstation_cluster.default",
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"etag", "annotations"},
+				ImportStateVerifyIgnore: []string{"etag", "annotations", "labels", "terraform_labels"},
 			},
 		},
 	})


### PR DESCRIPTION
<!-- Put a description of what this PR is for here, along with any references to issues that this resolves or contributes to -->


<!--
Please self-review your PR against the review checklist before creating it: https://googlecloudplatform.github.io/magic-modules/contribute/review-pr/

Completing the checklist will help speed up the review process, and we appreciate you spending time on them before sending
your code to be reviewed.

If your PR is still work in progress, please create it in draft mode
-->

<!-- AUTOCHANGELOG for Downstream PRs.

Please select one of the following "release-note:" headings:
    - release-note:enhancement
    - release-note:bug
    - release-note:note
    - release-note:new-resource
    - release-note:new-datasource
    - release-note:deprecation
    - release-note:breaking-change
    - release-note:none

Unless you choose release-note:none, please add a release note.

See https://googlecloudplatform.github.io/magic-modules/contribute/release-notes/ for writing good release notes.

You can add more release note blocks if you want more than one CHANGELOG
entry for this PR.
-->
**Release Note Template for Downstream PRs (will be copied)**

```release-note:
Set the default value of reconcileConnections from Service Attachment API
```
